### PR TITLE
docs(readme): add file location convention with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ export const routes: Routes = [
 
 **NOTE**: When specifying a relative path to lazy loaded module, one of the following two conditions *must* hold:
 
-* The lazy loaded route is defined in the same module file where it is added by `RouterModule.forXxx()`
-* The lazy loaded route is defined in a separate routing file, and that routing file is a sibling of module file (hence the routing file cannot be e.g. in a subdirectory).
+* The routes are defined in the same module file where it is imported with `RouterModule.forRoot` or `RouterModule.forChild`
+* The routes are defined in a separate routing file, and that routing file is a sibling of module file.
 
 ## Synchronous Loading
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ export const routes: Routes = [
 ];
 ```
 
+**NOTE**: When specifying a relative path to lazy loaded module, one of the following two conditions *must* hold:
+
+* The lazy loaded route is defined in the same module file where it is added by `RouterModule.forXxx()`
+* The lazy loaded route is defined in a separate routing file, and that routing file is a sibling of module file (hence the routing file cannot be e.g. in a subdirectory).
+
 ## Synchronous Loading
 
 For synchronous module loading, add the `sync=true` as a query string value to your `loadChildren` string. The module will be included in your bundle and not lazy-loaded.


### PR DESCRIPTION
Closes #52 .

Potentially still work-in-progress: having some more info on absolute path usage, docs could be further improved.