### PR TITLE
Updated loadChildren regex to be able to use double/single-quotes

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -24,7 +24,21 @@ describe('Loader', function() {
       `loadChildren: "${modulePath}"`,
       `loadChildren:"${modulePath}"`,
       `loadChildren :"${modulePath}"`,
-      `loadChildren : "${modulePath}"`
+      `loadChildren : "${modulePath}"`,
+
+      `"loadChildren":"${modulePath}"`,
+      `"loadChildren": "${modulePath}"`,
+      `"loadChildren" : "${modulePath}"`,
+      `"loadChildren" :  "${modulePath}"`,
+      `"loadChildren"  :"${modulePath}"`,
+      `"loadChildren"  : "${modulePath}"`,
+
+      `'loadChildren':"${modulePath}"`,
+      `'loadChildren': "${modulePath}"`,
+      `'loadChildren' : "${modulePath}"`,
+      `'loadChildren' :  "${modulePath}"`,
+      `'loadChildren'  :"${modulePath}"`,
+      `'loadChildren'  : "${modulePath}"`
     ];
 
     loadStrings.forEach(function(loadString) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ module.exports = function(source, sourcemap) {
   this.cacheable && this.cacheable();
 
   // regex for loadChildren string
-  var loadChildrenRegex = /loadChildren[\s]*:[\s]*['|"](.*?)['|"]/gm;
+  var loadChildrenRegex = /["']?loadChildren["']?[\s]*:[\s]*['|"](.*?)['|"]/gm;
 
   // parse query params
   var query = loaderUtils.getOptions(this) || {};


### PR DESCRIPTION
This fix make it possible to use double-quotes and single-quotes around the "loadChildren"-propertyn in the route configuration.

Why do I need this (and possibly others too)?
I generate my route-config based on JSON-output, where I get double-quotes around all properties, like this:

`{
    "path":"my/path",
    "loadChildren":"path/to/module",
    ...
}`