### PR TITLE
feat(loader): Add promise rejection upon loader error

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -29,9 +29,11 @@ replacement
 ```ts
 {
   path: 'lazy',
-  loadChildren: () => new Promise(function (resolve) {
+  loadChildren: () => new Promise(function (resolve, reject) {
     (require as any).ensure([], function (require: any) {
       resolve(require('./lazy/lazy.module')['LazyModule']);
+    }, function () {
+      reject({ loadChunkError: true });
     });
   })
 }
@@ -45,19 +47,19 @@ replacement
 ```ts
 {
   path: 'lazy',
-  loadChildren: () => System.import('./lazy/lazy.module').then(module => module['LazyModule'])
+  loadChildren: () => System.import('./lazy/lazy.module')
+    .then(module => module['LazyModule'], () => { throw({ loadChunkError: true }); })
 }
 ```
 
 To use `dynamic import`, set the `loader` to `import`
 
-**NOTE:** Using `import` only works with Webpack >= 2.1.0.
-
 replacement
 ```ts
 {
   path: 'lazy',
-  loadChildren: () => import('./lazy/lazy.module').then(module => module['LazyModule'])
+  loadChildren: () => import('./lazy/lazy.module')
+    .then(module => module['LazyModule'], () => { throw({ loadChunkError: true }); })
 }
 ```
 
@@ -144,6 +146,8 @@ replacement
   loadChildren: () => new Promise(function (resolve) {
     (require as any).ensure([], function (require: any) {
       resolve(require('./lazy/lazy.module.ngfactory')['LazyModuleNgFactory']);
+    }, function () {
+      reject({ loadChunkError: true });
     });
   })
 }
@@ -170,6 +174,8 @@ replacement (require loader)
   loadChildren: () => new Promise(function (resolve) {
     (require as any).ensure([], function (require: any) {
       resolve(require('./lazy/lazy.module')['LazyModule']);
+    }, function () {
+      reject({ loadChunkError: true });
     }, 'MyChunk');
   })
 }
@@ -179,7 +185,8 @@ replacement (system loader)
 ```ts
 {
   path: 'lazy',
-  loadChildren: () => System.import(/* webpackChunkName: "MyChunk" */ './lazy/lazy.module').then(module => module['LazyModule'])
+  loadChildren: () => System.import(/* webpackChunkName: "MyChunk" */ './lazy/lazy.module')
+    .then(module => module['LazyModule'], () => { throw({ loadChunkError: true }); })
 }
 ```
 
@@ -187,6 +194,7 @@ replacement (import loader)
 ```ts
 {
   path: 'lazy',
-  loadChildren: () => import(/* webpackChunkName: "MyChunk" */ './lazy/lazy.module').then(module => module['LazyModule'])
+  loadChildren: () => import(/* webpackChunkName: "MyChunk" */ './lazy/lazy.module')
+    .then(module => module['LazyModule'], () => { throw({ loadChunkError: true }); })
 }
 ```

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "mocha": "^3.0.2",
     "pmock": "^0.2.3",
     "should": "^11.1.0"
+  },
+  "peerDependencies": {
+    "webpack": ">=2.4.0"
   }
 }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -45,9 +45,11 @@ describe('Loader', function() {
       it(loadString, function() {
 
         var result = [
-          'loadChildren: () => new Promise(function (resolve) {',
+          'loadChildren: () => new Promise(function (resolve, reject) {',
           '  (require as any).ensure([], function (require: any) {',
           '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+          '  }, function () {',
+          '    reject({ loadChunkError: true });',
           '  });',
           '})'
         ];
@@ -73,9 +75,11 @@ describe('Loader', function() {
       loadStrings.forEach(function(loadString) {
         it(loadString, function() {
           var result = [
-            'loadChildren: () => new Promise(function (resolve) {',
+            'loadChildren: () => new Promise(function (resolve, reject) {',
             '  (require as any).ensure([], function (require: any) {',
             '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+            '  }, function () {',
+            '    reject({ loadChunkError: true });',
             '  });',
             '})'
           ];
@@ -95,9 +99,11 @@ describe('Loader', function() {
 
   it('should return a loadChildren async require statement', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -112,9 +118,11 @@ describe('Loader', function() {
 
   it('should return a plain javascript loadChildren async require statement', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  require.ensure([], function (require) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -144,9 +152,11 @@ describe('Loader', function() {
 
   it('should return a loadChildren chunkName require statement', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  }, \'name\');',
       '})'
     ];
@@ -162,7 +172,7 @@ describe('Loader', function() {
   it ('should return a loadChildren System.import statement', function() {
     var result = [
       'loadChildren: () => System.import(\'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'])'
+      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); })'
     ];
 
     var loadedString = loader.call({
@@ -176,7 +186,7 @@ describe('Loader', function() {
   it ('should return a loadChildren chunkName System.import statement', function() {
     var result = [
       'loadChildren: () => System.import(/* webpackChunkName: "name" */ \'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'])'
+      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); })'
     ];
 
     var loadedString = loader.call({
@@ -190,7 +200,7 @@ describe('Loader', function() {
   it ('should return a loadChildren dynamic import statement', function() {
     var result = [
       'loadChildren: () => import(\'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'])'
+      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); })'
     ];
 
     var loadedString = loader.call({
@@ -204,7 +214,7 @@ describe('Loader', function() {
   it ('should return a loadChildren chunkName dynamic import statement', function() {
     var result = [
       'loadChildren: () => import(/* webpackChunkName: "name" */ \'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'])'
+      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); })'
     ];
 
     var loadedString = loader.call({
@@ -219,9 +229,11 @@ describe('Loader', function() {
     var modulePath = './path/to/file.module';
 
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'default\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -236,9 +248,11 @@ describe('Loader', function() {
 
   it('should support a custom delimiter', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -256,9 +270,11 @@ describe('Loader', function() {
     var env = pmock.platform('win32');
 
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'.\\\\path\\\\to\\\\file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -275,9 +291,11 @@ describe('Loader', function() {
 
   it('should support non-relative paths', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve) {',
+      'loadChildren: () => new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'path/to/file.module\')[\'FileModule\']);',
+      '  }, function () {',
+      '    reject({ loadChunkError: true });',
       '  });',
       '})'
     ];
@@ -297,10 +315,12 @@ describe('Loader', function() {
 
     it('should return a loadChildren async require statement', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module.ngfactory\')[\'FileModuleNgFactory\']);',
-        '  });',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  });',  
         '})'
       ];
 
@@ -330,7 +350,7 @@ describe('Loader', function() {
     it ('should return a loadChildren System.import statement', function() {
       var result = [
         'loadChildren: () => System.import(\'./path/to/file.module.ngfactory\')',
-        '  .then(module => module[\'FileModuleNgFactory\'])'
+        '  .then(module => module[\'FileModuleNgFactory\'], () => { throw({ loadChunkError: true }); })'
       ];
 
       var loadedString = loader.call({
@@ -344,7 +364,7 @@ describe('Loader', function() {
     it ('should return a loadChildren dynamic import statement', function() {
       var result = [
         'loadChildren: () => import(\'./path/to/file.module.ngfactory\')',
-        '  .then(module => module[\'FileModuleNgFactory\'])'
+        '  .then(module => module[\'FileModuleNgFactory\'], () => { throw({ loadChunkError: true }); })'
       ];
 
       var loadedString = loader.call({
@@ -359,10 +379,12 @@ describe('Loader', function() {
       var moduleSuffix = '.ngfile';
 
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module' + moduleSuffix + '\')[\'FileModuleNgFactory\']);',
-        '  });',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  });',  
         '})'
       ];
 
@@ -378,9 +400,11 @@ describe('Loader', function() {
       var factorySuffix = 'NgFact';
 
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module.ngfactory\')[\'FileModule' + factorySuffix + '\']);',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
         '  });',
         '})'
       ];
@@ -395,10 +419,12 @@ describe('Loader', function() {
 
     it('should support non-relative paths', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'path/to/file.module.ngfactory\')[\'FileModuleNgFactory\']);',
-        '  });',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  });',  
         '})'
       ];
 
@@ -421,10 +447,12 @@ describe('Loader', function() {
 
     it('should return a loadChildren async require statement', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'../../../compiled/src/app/groups/inventory/index.ngfactory\')[\'InventoryModuleNgFactory\']);',
-        '  });',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  });',  
         '})'
       ];
 

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -32,10 +32,12 @@ describe('Utils', function() {
 
     it('should return an asynchronous require loadChildren statement with chunkName parameter', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  }, \'name\');',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  }, \'name\');',  
         '})'
       ];
       getRequireLoader('path', 'name', 'name', true).should.eql(result.join(''));
@@ -43,10 +45,12 @@ describe('Utils', function() {
 
     it('should return an asynchronous require loadChildren statement without chunkName parameter', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  });',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  });',  
         '})'
       ];
       getRequireLoader('path', undefined, 'name', true).should.eql(result.join(''));
@@ -54,10 +58,12 @@ describe('Utils', function() {
 
     it('should return an asynchronous require loadChildren statement with vanilla javascript', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve) {',
+        'loadChildren: () => new Promise(function (resolve, reject) {',
         '  require.ensure([], function (require) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  }, \'name\');',
+        '  }, function () {',
+        '    reject({ loadChunkError: true });',
+        '  }, \'name\');',  
         '})'
       ];
       getRequireLoader('path', 'name', 'name', true, true).should.eql(result.join(''));
@@ -71,7 +77,7 @@ describe('Utils', function() {
     it('should return an asynchronous System.import loadChildren statement', function() {
       var result = [
         'loadChildren: () => System.import(\'' + path + '\')',
-        '  .then(module => module[\'' + name + '\'])'
+        '  .then(module => module[\'' + name + '\'], () => { throw({ loadChunkError: true }); })'
       ];
 
       getSystemLoader('path', 'name', true).should.eql(result.join(''));
@@ -84,7 +90,7 @@ describe('Utils', function() {
     it('should return an asynchronous dynamic import loadChildren statement', function() {
       var result = [
         'loadChildren: () => import(\'' + path + '\')',
-        '  .then(module => module[\'' + name + '\'])'
+        '  .then(module => module[\'' + name + '\'], () => { throw({ loadChunkError: true }); })'
       ];
 
       getImportLoader('path', 'name', true).should.eql(result.join(''));

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,9 +21,11 @@ module.exports.getRequireLoader = function(filePath, chunkName, moduleName, inli
   var requireString = module.exports.getRequireString(filePath, moduleName);
 
   var result = [
-    'loadChildren: () => new Promise(function (resolve) {',
+    'loadChildren: () => new Promise(function (resolve, reject) {',
     '  ' + (isJs ? 'require' : '(require as any)') + '.ensure([], function (' + (isJs ? 'require' : 'require: any') + ') {',
     '    resolve(' + requireString + ');',
+    '  }, function () {',
+    '    reject({ loadChunkError: true });',
     '  }' + module.exports.getChunkName('require', chunkName) + ');',
     '})'
   ];
@@ -34,7 +36,7 @@ module.exports.getRequireLoader = function(filePath, chunkName, moduleName, inli
 module.exports.getSystemLoader = function(filePath, moduleName, inline, chunkName) {
   var result = [
     'loadChildren: () => System.import(' + module.exports.getChunkName('system', chunkName) + '\'' + filePath + '\')',
-    '  .then(module => module[\'' + moduleName + '\'])'
+    '  .then(module => module[\'' + moduleName + '\'], () => { throw({ loadChunkError: true }); })'
   ];
 
   return inline ? result.join('') : result.join('\n');
@@ -43,7 +45,7 @@ module.exports.getSystemLoader = function(filePath, moduleName, inline, chunkNam
 module.exports.getImportLoader = function(filePath, moduleName, inline, chunkName) {
   var result = [
     'loadChildren: () => import(' + module.exports.getChunkName('import', chunkName) + '\'' + filePath + '\')',
-    '  .then(module => module[\'' + moduleName + '\'])'
+    '  .then(module => module[\'' + moduleName + '\'], () => { throw({ loadChunkError: true }); })'
   ];
 
   return inline ? result.join('') : result.join('\n');


### PR DESCRIPTION
BREAKING CHANGES: Webpack >= 2.4 is required for the error callback to be supported with require.ensure and chunk names for dynamic imports.

BEFORE:

Webpack < 2.4 is supported

AFTER:

Webpack >= 2.4 is supported

Closes #75