### PR TITLE
fix: Update vanilla JS require loader te be fully ES5

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -118,13 +118,13 @@ describe('Loader', function() {
 
   it('should return a plain javascript loadChildren async require statement', function() {
     var result = [
-      'loadChildren: () => new Promise(function (resolve, reject) {',
+      'loadChildren: function () { return new Promise(function (resolve, reject) {',
       '  require.ensure([], function (require) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
       '  }, function () {',
       '    reject({ loadChunkError: true });',
       '  });',
-      '})'
+      '})}'
     ];
 
     var loadedString = loader.call({

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -58,13 +58,13 @@ describe('Utils', function() {
 
     it('should return an asynchronous require loadChildren statement with vanilla javascript', function() {
       var result = [
-        'loadChildren: () => new Promise(function (resolve, reject) {',
+        'loadChildren: function () { return new Promise(function (resolve, reject) {',
         '  require.ensure([], function (require) {',
         '    resolve(' + getRequireString(path, name) + ');',
         '  }, function () {',
         '    reject({ loadChunkError: true });',
         '  }, \'name\');',  
-        '})'
+        '})}'
       ];
       getRequireLoader('path', 'name', 'name', true, true).should.eql(result.join(''));
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,13 +21,13 @@ module.exports.getRequireLoader = function(filePath, chunkName, moduleName, inli
   var requireString = module.exports.getRequireString(filePath, moduleName);
 
   var result = [
-    'loadChildren: () => new Promise(function (resolve, reject) {',
+    'loadChildren: '+ (isJs ? 'function () { return' : '() =>') + ' new Promise(function (resolve, reject) {',
     '  ' + (isJs ? 'require' : '(require as any)') + '.ensure([], function (' + (isJs ? 'require' : 'require: any') + ') {',
     '    resolve(' + requireString + ');',
     '  }, function () {',
     '    reject({ loadChunkError: true });',
     '  }' + module.exports.getChunkName('require', chunkName) + ');',
-    '})'
+    '})' + (isJs ? '}' : '')
   ];
 
   return inline ? result.join('') : result.join('\n');


### PR DESCRIPTION
Fixes https://github.com/brandonroberts/angular-router-loader/issues/96

I forgot to update one of the tests in my previous PR.