### PR TITLE
Include additional error details when being unable to load chunk

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -48,8 +48,8 @@ describe('Loader', function() {
           'loadChildren: function() { return new Promise(function (resolve, reject) {',
           '  (require as any).ensure([], function (require: any) {',
           '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-          '  }, function() {',
-          '    reject({ loadChunkError: true });',
+          '  }, function(e) {',
+          '    reject({ loadChunkError: true, details: e });',
           '  });',
           '}) }'
         ];
@@ -78,8 +78,8 @@ describe('Loader', function() {
             'loadChildren: function() { return new Promise(function (resolve, reject) {',
             '  (require as any).ensure([], function (require: any) {',
             '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-            '  }, function() {',
-            '    reject({ loadChunkError: true });',
+            '  }, function(e) {',
+            '    reject({ loadChunkError: true, details: e });',
             '  });',
             '}) }'
           ];
@@ -102,8 +102,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -121,8 +121,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  require.ensure([], function (require) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -155,8 +155,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  }, \'name\');',
       '}) }'
     ];
@@ -172,7 +172,7 @@ describe('Loader', function() {
   it ('should return a loadChildren System.import statement', function() {
     var result = [
       'loadChildren: function() { return System.import(\'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); }) }'
+      '  .then(module => module[\'FileModule\'], e => { throw({ loadChunkError: true, details: e }); }) }'
     ];
 
     var loadedString = loader.call({
@@ -186,7 +186,7 @@ describe('Loader', function() {
   it ('should return a loadChildren chunkName System.import statement', function() {
     var result = [
       'loadChildren: function() { return System.import(/* webpackChunkName: "name" */ \'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); }) }'
+      '  .then(module => module[\'FileModule\'], e => { throw({ loadChunkError: true, details: e }); }) }'
     ];
 
     var loadedString = loader.call({
@@ -200,7 +200,7 @@ describe('Loader', function() {
   it ('should return a loadChildren dynamic import statement', function() {
     var result = [
       'loadChildren: function() { return import(\'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); }) }'
+      '  .then(module => module[\'FileModule\'], e => { throw({ loadChunkError: true, details: e }); }) }'
     ];
 
     var loadedString = loader.call({
@@ -214,7 +214,7 @@ describe('Loader', function() {
   it ('should return a loadChildren chunkName dynamic import statement', function() {
     var result = [
       'loadChildren: function() { return import(/* webpackChunkName: "name" */ \'./path/to/file.module\')',
-      '  .then(module => module[\'FileModule\'], () => { throw({ loadChunkError: true }); }) }'
+      '  .then(module => module[\'FileModule\'], e => { throw({ loadChunkError: true, details: e }); }) }'
     ];
 
     var loadedString = loader.call({
@@ -232,8 +232,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'default\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -251,8 +251,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'./path/to/file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -273,8 +273,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'.\\\\path\\\\to\\\\file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -294,8 +294,8 @@ describe('Loader', function() {
       'loadChildren: function() { return new Promise(function (resolve, reject) {',
       '  (require as any).ensure([], function (require: any) {',
       '    resolve(require(\'path/to/file.module\')[\'FileModule\']);',
-      '  }, function() {',
-      '    reject({ loadChunkError: true });',
+      '  }, function(e) {',
+      '    reject({ loadChunkError: true, details: e });',
       '  });',
       '}) }'
     ];
@@ -318,8 +318,8 @@ describe('Loader', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module.ngfactory\')[\'FileModuleNgFactory\']);',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',  
         '}) }'
       ];
@@ -350,7 +350,7 @@ describe('Loader', function() {
     it ('should return a loadChildren System.import statement', function() {
       var result = [
         'loadChildren: function() { return System.import(\'./path/to/file.module.ngfactory\')',
-        '  .then(module => module[\'FileModuleNgFactory\'], () => { throw({ loadChunkError: true }); }) }'
+        '  .then(module => module[\'FileModuleNgFactory\'], e => { throw({ loadChunkError: true, details: e }); }) }'
       ];
 
       var loadedString = loader.call({
@@ -364,7 +364,7 @@ describe('Loader', function() {
     it ('should return a loadChildren dynamic import statement', function() {
       var result = [
         'loadChildren: function() { return import(\'./path/to/file.module.ngfactory\')',
-        '  .then(module => module[\'FileModuleNgFactory\'], () => { throw({ loadChunkError: true }); }) }'
+        '  .then(module => module[\'FileModuleNgFactory\'], e => { throw({ loadChunkError: true, details: e }); }) }'
       ];
 
       var loadedString = loader.call({
@@ -382,8 +382,8 @@ describe('Loader', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module' + moduleSuffix + '\')[\'FileModuleNgFactory\']);',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',  
         '}) }'
       ];
@@ -403,8 +403,8 @@ describe('Loader', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'./path/to/file.module.ngfactory\')[\'FileModule' + factorySuffix + '\']);',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',
         '}) }'
       ];
@@ -422,8 +422,8 @@ describe('Loader', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'path/to/file.module.ngfactory\')[\'FileModuleNgFactory\']);',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',  
         '}) }'
       ];
@@ -450,8 +450,8 @@ describe('Loader', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(require(\'../../../compiled/src/app/groups/inventory/index.ngfactory\')[\'InventoryModuleNgFactory\']);',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',  
         '}) }'
       ];

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -35,8 +35,8 @@ describe('Utils', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  }, \'name\');',  
         '}) }'
       ];
@@ -48,8 +48,8 @@ describe('Utils', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  (require as any).ensure([], function (require: any) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  });',  
         '}) }'
       ];
@@ -61,8 +61,8 @@ describe('Utils', function() {
         'loadChildren: function() { return new Promise(function (resolve, reject) {',
         '  require.ensure([], function (require) {',
         '    resolve(' + getRequireString(path, name) + ');',
-        '  }, function() {',
-        '    reject({ loadChunkError: true });',
+        '  }, function(e) {',
+        '    reject({ loadChunkError: true, details: e });',
         '  }, \'name\');',  
         '}) }'
       ];
@@ -77,7 +77,7 @@ describe('Utils', function() {
     it('should return an asynchronous System.import loadChildren statement', function() {
       var result = [
         'loadChildren: function() { return System.import(\'' + path + '\')',
-        '  .then(module => module[\'' + name + '\'], () => { throw({ loadChunkError: true }); }) }'
+        '  .then(module => module[\'' + name + '\'], e => { throw({ loadChunkError: true, details: e }); }) }'
       ];
 
       getSystemLoader('path', 'name', true).should.eql(result.join(''));
@@ -90,7 +90,7 @@ describe('Utils', function() {
     it('should return an asynchronous dynamic import loadChildren statement', function() {
       var result = [
         'loadChildren: function() { return import(\'' + path + '\')',
-        '  .then(module => module[\'' + name + '\'], () => { throw({ loadChunkError: true }); }) }'
+        '  .then(module => module[\'' + name + '\'], e => { throw({ loadChunkError: true, details: e }); }) }'
       ];
 
       getImportLoader('path', 'name', true).should.eql(result.join(''));

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,8 +24,8 @@ module.exports.getRequireLoader = function(filePath, chunkName, moduleName, inli
     'loadChildren: function() { return new Promise(function (resolve, reject) {',
     '  ' + (isJs ? 'require' : '(require as any)') + '.ensure([], function (' + (isJs ? 'require' : 'require: any') + ') {',
     '    resolve(' + requireString + ');',
-    '  }, function() {',
-    '    reject({ loadChunkError: true });',
+    '  }, function(e) {',
+    '    reject({ loadChunkError: true, details: e });',
     '  }' + module.exports.getChunkName('require', chunkName) + ');',
     '}) }'
   ];
@@ -36,7 +36,7 @@ module.exports.getRequireLoader = function(filePath, chunkName, moduleName, inli
 module.exports.getSystemLoader = function(filePath, moduleName, inline, chunkName) {
   var result = [
     'loadChildren: function() { return System.import(' + module.exports.getChunkName('system', chunkName) + '\'' + filePath + '\')',
-    '  .then(module => module[\'' + moduleName + '\'], () => { throw({ loadChunkError: true }); }) }'
+    '  .then(module => module[\'' + moduleName + '\'], e => { throw({ loadChunkError: true, details: e }); }) }'
   ];
 
   return inline ? result.join('') : result.join('\n');
@@ -45,7 +45,7 @@ module.exports.getSystemLoader = function(filePath, moduleName, inline, chunkNam
 module.exports.getImportLoader = function(filePath, moduleName, inline, chunkName) {
   var result = [
     'loadChildren: function() { return import(' + module.exports.getChunkName('import', chunkName) + '\'' + filePath + '\')',
-    '  .then(module => module[\'' + moduleName + '\'], () => { throw({ loadChunkError: true }); }) }'
+    '  .then(module => module[\'' + moduleName + '\'], e => { throw({ loadChunkError: true, details: e }); }) }'
   ];
 
   return inline ? result.join('') : result.join('\n');


### PR DESCRIPTION
I've hit a case where the chunk loading was rejected because I exported two components in the same file (weird, but okay).

All I got from the ARL was `{ loadChunkError: true }` which wasn't saying much.

With this PR I added a `detail` literal to the thrown error object, which includes the error.